### PR TITLE
fix: Sgoinfre permissions retrieving before msg_goinfre_permissions var is constructed

### DIFF
--- a/42free.sh
+++ b/42free.sh
@@ -62,6 +62,13 @@ script_path="$script_dir/42free.sh"
 sgoinfre_root=$(find /sgoinfre/ -type d -name "$USER" -print -quit 2>/dev/null | grep -oE "^.*$USER" | head -n 1)
 sgoinfre_alt="/nfs/$sgoinfre_root"
 sgoinfre="$sgoinfre_root"
+sgoinfre_permissions=$( \
+    if [[ "$os_name" == "Linux" ]]; then
+        stat -c %A "$sgoinfre"
+    elif [[ "$os_name" == "Darwin" ]]; then
+        stat -f %Sp "$sgoinfre"
+    fi 2>/dev/null
+)
 
 # Shell config files
 bash_config="$HOME/.bashrc"


### PR DESCRIPTION
The issue of not displaying the current permissions was caused by retrieving `sgoinfre_permissions `after initializing `msg_sgoinfre_permissions` and `msg_sgoinfre_permissions_keep`.
As a result, it was constructed with an empty `sgoinfre_permissions` variable.